### PR TITLE
Remove date from supported attribute types

### DIFF
--- a/primer/1.3/gexf-13-primer.tex
+++ b/primer/1.3/gexf-13-primer.tex
@@ -263,7 +263,7 @@ A bunch of data can be stored within attributes. The concept is the same as tabl
 \subsubsection{Data types}
 
 \paragraph{}
-GEXF uses the XML Schema Data Types (\href{http://www.w3.org/TR/xmlschema-2/}{XSD 1.1}) for the following primitives: \href{http://www.w3.org/TR/xmlschema-2/#string}{string}, \href{http://www.w3.org/TR/xmlschema-2/#integer}{integer}, \href{http://www.w3.org/TR/xmlschema-2/#long}{long}, \href{http://www.w3.org/TR/xmlschema-2/#float}{float}, \href{http://www.w3.org/TR/xmlschema-2/#double}{double}, \href{http://www.w3.org/TR/xmlschema-2/#boolean}{boolean}, \href{http://www.w3.org/TR/xmlschema-2/#short}{short}, \href{http://www.w3.org/TR/xmlschema-2/#byte}{byte}, \href{http://www.w3.org/TR/xmlschema-2/#date}{date}, and \href{http://www.w3.org/TR/xmlschema-2/#anyURI}{anyURI}.
+GEXF uses the XML Schema Data Types (\href{http://www.w3.org/TR/xmlschema-2/}{XSD 1.1}) for the following primitives: \href{http://www.w3.org/TR/xmlschema-2/#string}{string}, \href{http://www.w3.org/TR/xmlschema-2/#integer}{integer}, \href{http://www.w3.org/TR/xmlschema-2/#long}{long}, \href{http://www.w3.org/TR/xmlschema-2/#float}{float}, \href{http://www.w3.org/TR/xmlschema-2/#double}{double}, \href{http://www.w3.org/TR/xmlschema-2/#boolean}{boolean}, \href{http://www.w3.org/TR/xmlschema-2/#short}{short}, \href{http://www.w3.org/TR/xmlschema-2/#byte}{byte}, and \href{http://www.w3.org/TR/xmlschema-2/#anyURI}{anyURI}.
 
 \paragraph{}
 In addition, GEXF supports additional Data Types: bigdecimal, biginteger, char, liststring, listboolean, listinteger, listlong, listfloat, listdouble, listbyte, listshort, listbigdecimal, listinteger and listchar.


### PR DESCRIPTION
It's not supported according to XSD - though it would be of value to have date/dateTime as supported attribute types.